### PR TITLE
webdav: fix file list display when initPath was not set

### DIFF
--- a/app/src/main/java/com/github/tvbox/osc/viewmodel/drive/WebDAVDriveViewModel.java
+++ b/app/src/main/java/com/github/tvbox/osc/viewmodel/drive/WebDAVDriveViewModel.java
@@ -64,7 +64,7 @@ public class WebDAVDriveViewModel extends AbstractDriveViewModel {
                     List<DriveFolderFile> items = new ArrayList<>();
                     if (files != null) {
                         for (DavResource file : files) {
-                            if (targetPath != null && file.getPath().toUpperCase(Locale.ROOT).endsWith(targetPath.toUpperCase(Locale.ROOT) + "/"))
+                            if (targetPath != "" && file.getPath().toUpperCase(Locale.ROOT).endsWith(targetPath.toUpperCase(Locale.ROOT) + "/"))
                                 continue;
                             int extNameStartIndex = file.getName().lastIndexOf(".");
                             items.add(new DriveFolderFile(currentDriveNote, file.getName(), !file.isDirectory(),


### PR DESCRIPTION
targetPath won't be null, because we assign it to "" when initPath not set.

Signed-off-by: Schspa Shi <schspa@gmail.com>