### PR TITLE
取消搜索名匹配限制

### DIFF
--- a/app/src/main/java/com/github/tvbox/osc/ui/activity/FastSearchActivity.java
+++ b/app/src/main/java/com/github/tvbox/osc/ui/activity/FastSearchActivity.java
@@ -453,15 +453,13 @@ public class FastSearchActivity extends BaseActivity {
         if (absXml != null && absXml.movie != null && absXml.movie.videoList != null && absXml.movie.videoList.size() > 0) {
             List<Movie.Video> data = new ArrayList<>();
             for (Movie.Video video : absXml.movie.videoList) {
-                if (video.name.contains(searchTitle)) {
-                    data.add(video);
-                    if (!resultVods.containsKey(video.sourceKey)) {
-                        resultVods.put(video.sourceKey, new ArrayList<Movie.Video>());
-                    }
-                    resultVods.get(video.sourceKey).add(video);
-                    if (video.sourceKey != lastSourceKey) {
-                        lastSourceKey = this.addWordAdapterIfNeed(video.sourceKey);
-                    }
+                data.add(video);
+                if (!resultVods.containsKey(video.sourceKey)) {
+                    resultVods.put(video.sourceKey, new ArrayList<Movie.Video>());
+                }
+                resultVods.get(video.sourceKey).add(video);
+                if (video.sourceKey != lastSourceKey) {
+                    lastSourceKey = this.addWordAdapterIfNeed(video.sourceKey);
                 }
             }
 

--- a/app/src/main/java/com/github/tvbox/osc/ui/activity/SearchActivity.java
+++ b/app/src/main/java/com/github/tvbox/osc/ui/activity/SearchActivity.java
@@ -468,7 +468,7 @@ public class SearchActivity extends BaseActivity {
         if (absXml != null && absXml.movie != null && absXml.movie.videoList != null && absXml.movie.videoList.size() > 0) {
             List<Movie.Video> data = new ArrayList<>();
             for (Movie.Video video : absXml.movie.videoList) {
-                if (matchSearchResult(video.name, searchTitle)) data.add(video);
+                data.add(video);
             }
             if (searchAdapter.getData().size() > 0) {
                 searchAdapter.addData(data);


### PR DESCRIPTION
首先contains不能区分字母大小写，搜索的时候，搜不出结果；其次，有时候网站视频标题与搜索词不一致是因为视频有多个标题，现有匹配限制太大，没有存在的必要，如果可以的话，可以添加一个模糊匹配的框来选择