### PR TITLE
解决部分视频无限卡顿，log循环显示FFP_MSG_BUFFERING_START，FFP_MSG_BUFFERING_END

### DIFF
--- a/app/src/main/java/com/github/tvbox/osc/player/IjkmPlayer.java
+++ b/app/src/main/java/com/github/tvbox/osc/player/IjkmPlayer.java
@@ -93,6 +93,7 @@ public class IjkmPlayer extends IjkPlayer {
         }
         //mMediaPlayer.setOption(IjkMediaPlayer.OPT_CATEGORY_FORMAT, "protocol_whitelist", "ijkio,ffio,async,cache,crypto,file,http,https,ijkhttphook,ijkinject,ijklivehook,ijklongurl,ijksegment,ijktcphook,pipe,rtp,tcp,tls,udp,ijkurlhook,data");
         mMediaPlayer.setOption(IjkMediaPlayer.OPT_CATEGORY_FORMAT, "protocol_whitelist", "ijkio,ffio,async,cache,crypto,file,http,https,ijkhttphook,ijkinject,ijklivehook,ijklongurl,ijksegment,ijktcphook,pipe,rtp,tcp,tls,udp,ijkurlhook,data,concat,subfile,ffconcat");
+        mMediaPlayer.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER, "packet-buffering", 0L);
         try {
             path = encodeSpaceChinese(path);
         } catch (Exception ignored) {


### PR DESCRIPTION
这个问题遇到好久了，今天调壳子log看，ijk解码下，无限跳FFP_MSG_BUFFERING_START，FFP_MSG_BUFFERING_END，网上搜说是什么缓冲问题，加了这行代码，至少视频能看了，实测有效