### PR TITLE
修复某些类会反射调用zxing导致生成阿里云二维码报错

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -220,7 +220,8 @@
 
 # 支持影视的ali相关的jar
 -keep class com.google.gson.**{*;}
-
+# 某些类会反射调用zxing导致生成阿里云二维码报错
+-keep class com.google.zxing.** {*;}
 #阿里云播放器
 -keep class com.alivc.**{*;}
 -keep class com.aliyun.**{*;}


### PR DESCRIPTION
LineageOS 20  TV模式下，编译出release版本打开阿里里云二难码时会报以下错误
--------- beginning of crash
12-14 21:30:07.886  6226  6226 E AndroidRuntime: FATAL EXCEPTION: main
12-14 21:30:07.886  6226  6226 E AndroidRuntime: Process: com.github.tvbox.osc.tk, PID: 6226
12-14 21:30:07.886  6226  6226 E AndroidRuntime: java.lang.NoClassDefFoundError: Failed resolution of: Lcom/google/zxing/EncodeHintType;
12-14 21:30:07.886  6226  6226 E AndroidRuntime: 	at com.github.catvod.spider.merge.J.a.a(Unknown Source:2)
12-14 21:30:07.886  6226  6226 E AndroidRuntime: 	at com.github.catvod.spider.merge.b.s.L(Unknown Source:29)
12-14 21:30:07.886  6226  6226 E AndroidRuntime: 	at com.github.catvod.spider.merge.b.s.j(Unknown Source:54)
12-14 21:30:07.886  6226  6226 E AndroidRuntime: 	at com.github.catvod.spider.merge.b.g.run(Unknown Source:6)
12-14 21:30:07.886  6226  6226 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:942)
12-14 21:30:07.886  6226  6226 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99)
12-14 21:30:07.886  6226  6226 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:201)
12-14 21:30:07.886  6226  6226 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:288)
12-14 21:30:07.886  6226  6226 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:7924)
12-14 21:30:07.886  6226  6226 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
12-14 21:30:07.886  6226  6226 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
12-14 21:30:07.886  6226  6226 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
12-14 21:30:07.886  6226  6226 E AndroidRuntime: Caused by: java.lang.ClassNotFoundException: com.google.zxing.EncodeHintType
12-14 21:30:07.886  6226  6226 E AndroidRuntime: 	... 12 more
12-14 21:30:08.191  4448  4750 E OpenGLRenderer: Unable to match the desired swap behavior.