### PR TITLE
Ignore “.DS_Store” file on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ lint/tmp/
 /LTDecodeSpace
 /adb.exe
 /LTDecodeNew3.exe
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Ignore the annoying .DS_Store files on macOS.