### PR TITLE
修改getExternalCacheDir().getAbsolutePath() 的方法修改为使用 FileUtils.getExternalCachePath(),防止空指针

### DIFF
--- a/app/src/main/java/com/github/tvbox/osc/base/App.java
+++ b/app/src/main/java/com/github/tvbox/osc/base/App.java
@@ -3,6 +3,7 @@ package com.github.tvbox.osc.base;
 import android.os.Environment;
 
 import androidx.multidex.MultiDexApplication;
+
 import com.github.catvod.crawler.JsLoader;
 import com.github.tvbox.osc.R;
 import com.github.tvbox.osc.callback.EmptyCallback;
@@ -20,6 +21,7 @@ import com.kingja.loadsir.core.LoadSir;
 import com.orhanobut.hawk.Hawk;
 import com.p2p.P2PClass;
 import com.whl.quickjs.android.QuickJSLoader;
+
 import java.io.File;
 
 import io.github.inflationx.calligraphy3.CalligraphyConfig;
@@ -39,7 +41,7 @@ public class App extends MultiDexApplication {
     public static String burl;
     private static String dashData;
     public static ViewPump viewPump = null;
-    
+
     @Override
     public void onCreate() {
         super.onCreate();
@@ -93,7 +95,7 @@ public class App extends MultiDexApplication {
     public static P2PClass getp2p() {
         try {
             if (p == null) {
-                p = new P2PClass(instance.getExternalCacheDir().getAbsolutePath());
+                p = new P2PClass(FileUtils.getExternalCachePath());
             }
             return p;
         } catch (Exception e) {
@@ -156,6 +158,7 @@ public class App extends MultiDexApplication {
     public void setDashData(String data) {
         dashData = data;
     }
+
     public String getDashData() {
         return dashData;
     }

--- a/app/src/main/java/com/github/tvbox/osc/util/FileUtils.java
+++ b/app/src/main/java/com/github/tvbox/osc/util/FileUtils.java
@@ -62,7 +62,7 @@ public class FileUtils {
         }
         return null;
     }
-    
+
     public static String readFileToString(String path, String charsetName) {
         // 定义返回结果
         StringBuilder jsonString = new StringBuilder();
@@ -121,11 +121,11 @@ public class FileUtils {
     }
 
     public static String loadModule(String name) {
-        try {        	
+        try {
             if (name.contains("gbk.js")) {
                 name = "gbk.js";
             } else if (name.contains("模板.js")) {
-                name = "模板.js";            
+                name = "模板.js";
             } else if (name.contains("cat.js")) {
                 name = "cat.js";
             }
@@ -212,7 +212,7 @@ public class FileUtils {
             return "";
         }
     }
-    
+
     public static byte[] getCacheByte(String name) {
         try {
             File file = open("B_" + name);
@@ -235,7 +235,7 @@ public class FileUtils {
             e.printStackTrace();
         }
     }
-    
+
     public static void setCacheByte(String name, byte[] data) {
         try {
             writeSimple(byteMerger("//DRPY".getBytes(),Base64.encode(data, Base64.URL_SAFE)), open("B_" + name));
@@ -243,19 +243,19 @@ public class FileUtils {
             e.printStackTrace();
         }
     }
-    
+
     public static byte[] byteMerger(byte[] bt1, byte[] bt2){
         byte[] bt3 = new byte[bt1.length+bt2.length];
         System.arraycopy(bt1, 0, bt3, 0, bt1.length);
         System.arraycopy(bt2, 0, bt3, bt1.length, bt2.length);
         return bt3;
     }
-    
+
     public static String get(String str) {
         return get(str, null);
     }
 
-    public static String get(String str, Map<String, String> headerMap) {    
+    public static String get(String str, Map<String, String> headerMap) {
         try {
             HttpHeaders h = new HttpHeaders();
             Response response = null;
@@ -276,7 +276,7 @@ public class FileUtils {
             return "";
         }
     }
-    
+
     private static final Pattern URLJOIN = Pattern.compile("^http.*\\.(js|txt|json|m3u)$", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
 
     public static File getCacheDir() {
@@ -286,13 +286,18 @@ public class FileUtils {
         return App.getInstance().getExternalCacheDir();
     }
     public static String getExternalCachePath() {
-        return getExternalCacheDir().getAbsolutePath();
+        //部分机器getExternalCacheDir()会返回空
+        File externalCacheDir = getExternalCacheDir();
+        if (externalCacheDir == null){
+            return getCachePath();
+        }
+        return externalCacheDir.getAbsolutePath();
     }
 
     public static String getCachePath() {
         return getCacheDir().getAbsolutePath();
     }
-    
+
     public static void cleanPlayerCache() {
         recursiveDelete(new File(getCachePath() + File.separator + "thunder"));
         recursiveDelete(new File(getExternalCachePath() + File.separator + "ijkcaches"));

--- a/app/src/main/java/com/github/tvbox/osc/util/FileUtils.java
+++ b/app/src/main/java/com/github/tvbox/osc/util/FileUtils.java
@@ -32,7 +32,7 @@ import okhttp3.Response;
 public class FileUtils {
 
     public static File open(String str) {
-        return new File(App.getInstance().getExternalCacheDir().getAbsolutePath() + "/qjscache_" + str + ".js");
+        return new File(getExternalCachePath() + "/qjscache_" + str + ".js");
     }
 
     public static boolean writeSimple(byte[] data, File dst) {

--- a/app/src/main/java/tv/danmaku/ijk/media/player/IjkMediaPlayer.java
+++ b/app/src/main/java/tv/danmaku/ijk/media/player/IjkMediaPlayer.java
@@ -43,6 +43,7 @@ import android.view.Surface;
 import android.view.SurfaceHolder;
 
 import com.github.tvbox.osc.base.App;
+import com.github.tvbox.osc.util.FileUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -405,18 +406,19 @@ public final class IjkMediaPlayer extends AbstractMediaPlayer {
      * Sets the data source (file-path or http/rtsp URL) to use.
      *
      * @param path the path of the file, or the http/rtsp URL of the stream you
-     *             want to play
+     * want to play
      * @throws IllegalStateException if it is called in an invalid state
      *
-     *                               <p>
-     *                               When <code>path</code> refers to a local file, the file may
-     *                               actually be opened by a process other than the calling
-     *                               application. This implies that the pathname should be an
-     *                               absolute path (as any other process runs with unspecified
-     *                               current working directory), and that the pathname should
-     *                               reference a world-readable file.
+     * <p>
+     * When <code>path</code> refers to a local file, the file may
+     * actually be opened by a process other than the calling
+     * application. This implies that the pathname should be an
+     * absolute path (as any other process runs with unspecified
+     * current working directory), and that the pathname should
+     * reference a world-readable file.
      */
     private boolean over = false;
+
     @Override
     public void setDataSource(String path)
             throws IOException, IllegalArgumentException, SecurityException, IllegalStateException {
@@ -465,7 +467,7 @@ public final class IjkMediaPlayer extends AbstractMediaPlayer {
     }
 
     public static String xml2ffconcat(String str) {
-        String str2 = App.getInstance().getExternalCacheDir().getPath() + "/" + System.currentTimeMillis() + ".ffconcat";
+        String str2 = FileUtils.getExternalCachePath() + "/" + System.currentTimeMillis() + ".ffconcat";
         try {
             File file = new File(str2);
             if (!file.exists()) {
@@ -484,6 +486,7 @@ public final class IjkMediaPlayer extends AbstractMediaPlayer {
         }
         return str2;
     }
+
     /**
      * Sets the data source (file-path or http/rtsp URL) to use.
      *

--- a/app/src/main/java/xyz/doikki/videoplayer/exo/ExoMediaSourceHelper.java
+++ b/app/src/main/java/xyz/doikki/videoplayer/exo/ExoMediaSourceHelper.java
@@ -28,6 +28,8 @@ import androidx.media3.extractor.DefaultExtractorsFactory;
 import androidx.media3.extractor.ExtractorsFactory;
 import androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory;
 import androidx.media3.extractor.ts.TsExtractor;
+
+import com.github.tvbox.osc.util.FileUtils;
 import com.google.androidx.media3.exoplayer.ext.okhttp.OkHttpDataSource;
 
 import java.io.File;
@@ -161,7 +163,7 @@ public final class ExoMediaSourceHelper {
     @SuppressLint("UnsafeOptInUsageError")
     private Cache newCache() {
         return new SimpleCache(
-                new File(mAppContext.getExternalCacheDir(), "exo-video-cache"),//缓存目录
+                new File(FileUtils.getExternalCachePath(), "exo-video-cache"),//缓存目录
                 new LeastRecentlyUsedCacheEvictor(512 * 1024 * 1024),//缓存大小，默认512M，使用LRU算法实现
                 new StandaloneDatabaseProvider(mAppContext));
     }


### PR DESCRIPTION
修改getExternalCacheDir().getAbsolutePath() 的方法修改为使用 FileUtils.getExternalCachePath(),防止空指针