### PR TITLE
回滚集数排序

### DIFF
--- a/app/src/main/java/com/github/tvbox/osc/ui/activity/DetailActivity.java
+++ b/app/src/main/java/com/github/tvbox/osc/ui/activity/DetailActivity.java
@@ -81,11 +81,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
@@ -699,20 +697,12 @@ public class DetailActivity extends BaseActivity {
                         arrayList.add(new VodSeriesGroup(name_s + "-" + size));
                     }
                 }
-                Collections.sort(info, sortComparator);
                 uu.add(info);
             }
         } catch (Exception e) {
         }
         return arrayList;
-    }
-
-    private final Comparator<VodInfo.VodSeries> sortComparator = new Comparator<VodInfo.VodSeries>() {
-        @Override
-        public int compare(VodInfo.VodSeries o1, VodInfo.VodSeries o2) {
-            return StringUtils.compare(o1.name.toUpperCase(Locale.CHINESE), o2.name.toUpperCase(Locale.CHINESE));
-        }
-    };
+    }  
 
     private void setTextShow(TextView view, String tag, String info) {
         if (info == null || info.trim().isEmpty()) {

--- a/app/src/main/java/com/github/tvbox/osc/util/StringUtils.java
+++ b/app/src/main/java/com/github/tvbox/osc/util/StringUtils.java
@@ -2,10 +2,8 @@ package com.github.tvbox.osc.util;
 
 
 import java.lang.reflect.Array;
-import java.text.Collator;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 public class StringUtils {
@@ -217,38 +215,5 @@ public class StringUtils {
             }
         }
         return result;
-    }
-
-    public static int compare(String s1, String s2) {
-        String[] split1 = splitString(s1);
-        String[] split2 = splitString(s2);
-
-        Collator collator = Collator.getInstance(Locale.CHINA);
-
-        // Compare each segment of the strings
-        for (int i = 0; i < Math.min(split1.length, split2.length); i++) {
-            if (Character.isDigit(split1[i].charAt(0)) && Character.isDigit(split2[i].charAt(0))) {
-                // Both segments are numeric, compare as numbers
-                int num1 = Integer.parseInt(split1[i]);
-                int num2 = Integer.parseInt(split2[i]);
-                int numComparison = Integer.compare(num1, num2);
-                if (numComparison != 0) {
-                    return numComparison;
-                }
-            } else {
-                // Compare as strings or Chinese characters
-                int stringComparison = collator.compare(split1[i], split2[i]);
-                if (stringComparison != 0) {
-                    return stringComparison;
-                }
-            }
-        }
-
-        // Handle case where one string is a prefix of the other
-        return Integer.compare(split1.length, split2.length);
-    }
-
-    private static String[] splitString(String s) {
-        return s.split("(?<=\\D)(?=\\d)|(?<=\\d)(?=\\D)");
     }
 }

--- a/app/src/main/java/com/github/tvbox/osc/viewmodel/drive/AbstractDriveViewModel.java
+++ b/app/src/main/java/com/github/tvbox/osc/viewmodel/drive/AbstractDriveViewModel.java
@@ -3,7 +3,6 @@ package com.github.tvbox.osc.viewmodel.drive;
 import androidx.lifecycle.ViewModel;
 
 import com.github.tvbox.osc.bean.DriveFolderFile;
-import com.github.tvbox.osc.util.StringUtils;
 
 import java.text.Collator;
 import java.util.Collections;
@@ -53,19 +52,16 @@ public abstract class AbstractDriveViewModel extends ViewModel {
         public int compare(DriveFolderFile o1, DriveFolderFile o2) {
             switch (sortType) {
                 case 1:
-//                    return Collator.getInstance(Locale.CHINESE).compare(o2.name.toUpperCase(Locale.CHINESE), o1.name.toUpperCase(Locale.CHINESE));
-                    return StringUtils.compare(o2.name.toUpperCase(Locale.CHINESE), o1.name.toUpperCase(Locale.CHINESE));
+                    return Collator.getInstance(Locale.CHINESE).compare(o2.name.toUpperCase(Locale.CHINESE), o1.name.toUpperCase(Locale.CHINESE));
                 case 2:
                     return Long.compare(o1.lastModifiedDate, o2.lastModifiedDate);
                 case 3:
                     return Long.compare(o2.lastModifiedDate, o1.lastModifiedDate);
                 default:
-//                    return Collator.getInstance(Locale.CHINESE).compare(o1.name.toUpperCase(Locale.CHINESE), o2.name.toUpperCase(Locale.CHINESE));
-                    return StringUtils.compare(o1.name.toUpperCase(Locale.CHINESE), o2.name.toUpperCase(Locale.CHINESE));
+                    return Collator.getInstance(Locale.CHINESE).compare(o1.name.toUpperCase(Locale.CHINESE), o2.name.toUpperCase(Locale.CHINESE));
             }
         }
     };
-
 
     public interface LoadDataCallback {
 
@@ -73,5 +69,4 @@ public abstract class AbstractDriveViewModel extends ViewModel {
 
         void fail(String message);
     }
-
 }


### PR DESCRIPTION
由于分页后在进行排序，会导致阿里视频的集数排序混乱。
比如说阿里一部剧里有MP4格式的 01-30  和MKV格式的01-30. 排序会导致在同个分页里集数混乱了

