### PR TITLE
开启图片缓存

### DIFF
--- a/app/src/main/java/com/github/tvbox/osc/util/ImgUtil.java
+++ b/app/src/main/java/com/github/tvbox/osc/util/ImgUtil.java
@@ -70,7 +70,7 @@ public class ImgUtil {
             if (roundingRadius == 0) roundingRadius = 1;
             RequestOptions requestOptions = new RequestOptions()
                 .format(DecodeFormat.PREFER_RGB_565)
-                .diskCacheStrategy(getDiskCacheStrategy(0))
+                .diskCacheStrategy(getDiskCacheStrategy(4))
                 .dontAnimate()
                 .transform(
             new CenterCrop(),


### PR DESCRIPTION
抓包看图片重复请求比较多，开启了图片缓存
最多会占用250M磁盘+15%可用内存