### PR TITLE
解决搜索页面闪退报错

### DIFF
--- a/app/src/main/java/com/github/tvbox/osc/util/ImgUtil.java
+++ b/app/src/main/java/com/github/tvbox/osc/util/ImgUtil.java
@@ -153,7 +153,7 @@ public class ImgUtil {
         if (url.contains("@User-Agent=")) ua = url.split("@User-Agent=")[1].split("@")[0];
         if (url.contains("@Referer=")) referer = url.split("@Referer=")[1].split("@")[0];
         url = url.split("@")[0];
-
+        if(TextUtils.isEmpty(url)) return null;
         /*   AuthInfo authInfo = new AuthInfo(url);
         url = authInfo.url; */
 


### PR DESCRIPTION
url修改之后没做判空
```
FATAL EXCEPTION: main
	java.lang.IllegalArgumentException: Must not be null or empty
	at androidx.base.uu.<init>(SourceFile:12)
	at androidx.base.jy.a(SourceFile:370)
	at com.github.tvbox.osc.ui.adapter.SearchAdapter.convert(SourceFile:150)
```