### PR TITLE
逆序时上一集/下一集与自动播放下一条按当前列表顺序切换

### DIFF
--- a/app/src/main/java/com/github/tvbox/osc/ui/activity/DetailActivity.java
+++ b/app/src/main/java/com/github/tvbox/osc/ui/activity/DetailActivity.java
@@ -299,7 +299,7 @@ public class DetailActivity extends BaseActivity {
                     }
                     refreshList();
                     insertVod(firstsourceKey, vodInfo);
-                    //seriesAdapter.notifyDataSetChanged();
+                    updateSortButtonText();
                 }
             }
         });
@@ -795,6 +795,8 @@ public class DetailActivity extends BaseActivity {
                             vodInfo.reverse();
                         }
 
+                        updateSortButtonText();
+
                         if (vodInfo.playFlag == null || !vodInfo.seriesMap.containsKey(vodInfo.playFlag))
                             vodInfo.playFlag = (String) vodInfo.seriesMap.keySet().toArray()[0];
 
@@ -833,6 +835,12 @@ public class DetailActivity extends BaseActivity {
                 }
             }
         });
+    }
+
+    private void updateSortButtonText() {
+        if (vodInfo != null && vodInfo.seriesMap != null && vodInfo.seriesMap.size() > 0) {
+            tvSort.setText(vodInfo.reverseSort ? R.string.det_sort_normal : R.string.det_sort);
+        }
     }
 
     private String getHtml(String label, String content) {

--- a/app/src/main/java/com/github/tvbox/osc/ui/activity/PlayActivity.java
+++ b/app/src/main/java/com/github/tvbox/osc/ui/activity/PlayActivity.java
@@ -300,14 +300,10 @@ public class PlayActivity extends BaseActivity {
                         }
                     }
                 }
-                if (mVodInfo.reverseSort) {
-                    PlayActivity.this.playPrevious();
-                } else {
-                    String preProgressKey = progressKey;
-                    PlayActivity.this.playNext(rmProgress);
-                    if (rmProgress && preProgressKey != null)
-                        CacheManager.delete(MD5.string2MD5(preProgressKey), 0);
-                }
+                String preProgressKey = progressKey;
+                PlayActivity.this.playNext(rmProgress);
+                if (rmProgress && preProgressKey != null)
+                    CacheManager.delete(MD5.string2MD5(preProgressKey), 0);
             }
 
             @Override
@@ -321,11 +317,7 @@ public class PlayActivity extends BaseActivity {
                         }
                     }
                 }
-                if (mVodInfo.reverseSort) {
-                    PlayActivity.this.playNext(false);
-                } else {
-                    PlayActivity.this.playPrevious();
-                }
+                PlayActivity.this.playPrevious();
             }
 
             @Override

--- a/app/src/main/java/com/github/tvbox/osc/ui/fragment/PlayFragment.java
+++ b/app/src/main/java/com/github/tvbox/osc/ui/fragment/PlayFragment.java
@@ -287,14 +287,10 @@ public class PlayFragment extends BaseLazyFragment {
                         }
                     }
                 }
-                if (mVodInfo.reverseSort) {
-                    PlayFragment.this.playPrevious();
-                } else {
-                    String preProgressKey = progressKey;
-                    PlayFragment.this.playNext(rmProgress);
-                    if (rmProgress && preProgressKey != null)
-                        CacheManager.delete(MD5.string2MD5(preProgressKey), 0);
-                }
+                String preProgressKey = progressKey;
+                PlayFragment.this.playNext(rmProgress);
+                if (rmProgress && preProgressKey != null)
+                    CacheManager.delete(MD5.string2MD5(preProgressKey), 0);
             }
 
             @Override
@@ -308,11 +304,7 @@ public class PlayFragment extends BaseLazyFragment {
                         }
                     }
                 }
-                if (mVodInfo.reverseSort) {
-                    PlayFragment.this.playNext(false);
-                } else {
-                    PlayFragment.this.playPrevious();
-                }
+                PlayFragment.this.playPrevious();
             }
 
             @Override

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -30,6 +30,7 @@
     <string name="det_expand">全屏</string>
     <string name="det_search">快搜</string>
     <string name="det_sort">倒序</string>
+    <string name="det_sort_normal">正序</string>
     <string name="det_push">推送</string>
     <string name="det_fav">收藏</string>
     <string name="det_fav_add">已添加收藏</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,8 @@
     <string name="det_play">Play</string>
     <string name="det_expand">Expand</string>
     <string name="det_search">Search</string>
-    <string name="det_sort">Sort</string>
+    <string name="det_sort">Reverse</string>
+    <string name="det_sort_normal">Normal</string>
     <string name="det_push">Push</string>
     <string name="det_fav">Favorite</string>
     <string name="det_fav_add">Added to Favorite</string>


### PR DESCRIPTION
## 修改说明
当用户点击详情页「倒序」后，剧集列表已逆序显示，但控制栏的「上一集」「下一集」以及自动播放下一条仍按原来的正序逻辑执行。

本次修改移除 `reverseSort` 时对 next/previous 的互换逻辑，使上一集、下一集、自动播放下一条均按**当前列表顺序**（即逆序后的顺序）切换。

## 涉及文件
- `PlayActivity.java`：独立播放页的下一集/上一集回调
- `PlayFragment.java`：详情页内嵌播放的下一集/上一集回调

基于提交: https://github.com/xx025/Box/commit/8f6bfe9

Made with [Cursor](https://cursor.com)